### PR TITLE
Non mandatory messages

### DIFF
--- a/emque-stats.gemspec
+++ b/emque-stats.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob('lib/**/*.rb')
   spec.files += Dir.glob('spec/**/*')
   spec.test_files = Dir.glob('spec/**/*')
-  spec.required_ruby_version = "~> 2.1.2"
 
-  spec.add_dependency "emque-producing", "1.0.0.beta2"
+  spec.add_dependency "emque-producing", "1.0.0.beta3"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake",    "~> 10.4"
-  spec.add_development_dependency "rspec",   "~> 3.2"
-  spec.add_development_dependency "bunny",   "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake",    "~> 10.4.2"
+  spec.add_development_dependency "rspec",   "~> 3.2.0"
+  spec.add_development_dependency "bunny",   "~> 1.7.0"
   spec.add_development_dependency "pry"
 end

--- a/emque-stats.gemspec
+++ b/emque-stats.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "emque-producing", "1.0.0.beta3"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.4.2"
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "bunny",   "~> 1.7.0"

--- a/lib/emque/stats/messages/count_message.rb
+++ b/lib/emque/stats/messages/count_message.rb
@@ -3,6 +3,7 @@ class CountMessage
 
   topic "metrics"
   message_type "metrics.count"
+  raise_on_failure false
 
   attribute :event_name, String, :required => true
   attribute :count, Integer, :required => true

--- a/lib/emque/stats/messages/event_message.rb
+++ b/lib/emque/stats/messages/event_message.rb
@@ -3,6 +3,7 @@ class EventMessage
 
   topic "metrics"
   message_type "metrics.event"
+  raise_on_failure false
 
   attribute :event_name, String, :required => true
   attribute :properties, Hash

--- a/lib/emque/stats/messages/gauge_message.rb
+++ b/lib/emque/stats/messages/gauge_message.rb
@@ -3,6 +3,7 @@ class GaugeMessage
 
   topic "metrics"
   message_type "metrics.gauge"
+  raise_on_failure false
 
   attribute :event_name, String, :required => true
   attribute :value, Integer, :required => true

--- a/lib/emque/stats/messages/meter_message.rb
+++ b/lib/emque/stats/messages/meter_message.rb
@@ -3,6 +3,7 @@ class MeterMessage
 
   topic "metrics"
   message_type "metrics.meter"
+  raise_on_failure false
 
   attribute :event_name, String, :required => true
 end

--- a/lib/emque/stats/messages/timer_message.rb
+++ b/lib/emque/stats/messages/timer_message.rb
@@ -3,6 +3,7 @@ class TimerMessage
 
   topic "metrics"
   message_type "metrics.timer"
+  raise_on_failure false
 
   attribute :event_name, String, :required => true
   attribute :duration, Integer, :required => true

--- a/lib/emque/stats/version.rb
+++ b/lib/emque/stats/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Stats
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
Assumes stats are non-critical. It bakes that assumption into the message class directly here, but perhaps it needs to be a producing time option that is passed in when instantiating the `Message`?