### PR TITLE
Separate rich event tracking into its own queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Send some stats
 
 ``` ruby
   # track activity
-  Emque::Stats.event("login", {:user_id => 1, :another_property => "something"} )
+  Emque::Stats.track("login", {:user_id => 1, :another_property => "something"} )
 
   # counter
   Emque::Stats.increment("garets")

--- a/lib/emque/stats.rb
+++ b/lib/emque/stats.rb
@@ -21,8 +21,8 @@ module Emque
         @configuration ||= Configuration.new
       end
 
-      def event(event_name, props = {})
-        Emque::Stats.client.produce_event(event_name, props)
+      def track(event_name, props = {})
+        Emque::Stats.client.produce_track_event(event_name, props)
       end
 
       def increment(event_name)

--- a/lib/emque/stats/client.rb
+++ b/lib/emque/stats/client.rb
@@ -2,7 +2,7 @@ require "emque-producing"
 require "emque/stats/messages/count_message"
 require "emque/stats/messages/gauge_message"
 require "emque/stats/messages/timer_message"
-require "emque/stats/messages/event_message"
+require "emque/stats/messages/track_event_message"
 
 module Emque
   module Stats
@@ -12,8 +12,8 @@ module Emque
         Emque::Producing.configuration = config.emque_producing_configuration
       end
 
-      def produce_event(event_name, properties = {})
-        message = EventMessage.new(:event_name => event_name, :properties => properties)
+      def produce_track_event(event_name, properties = {})
+        message = TrackEventMessage.new(:event_name => event_name, :properties => properties)
         message.publish
       end
 

--- a/lib/emque/stats/messages/track_event_message.rb
+++ b/lib/emque/stats/messages/track_event_message.rb
@@ -1,8 +1,8 @@
-class EventMessage
+class TrackEventMessage
   include Emque::Producing::Message
 
-  topic "metrics"
-  message_type "metrics.event"
+  topic "track"
+  message_type "track.event"
   raise_on_failure false
 
   attribute :event_name, String, :required => true

--- a/lib/emque/stats/version.rb
+++ b/lib/emque/stats/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Stats
-    VERSION = "0.0.2"
+    VERSION = "1.0.0.beta1"
   end
 end

--- a/spec/stats/client_spec.rb
+++ b/spec/stats/client_spec.rb
@@ -9,7 +9,7 @@ describe Emque::Stats::Client do
   }
 
   it "produces event" do
-    subject.produce_event("signin")
+    subject.produce_track_event("signin")
   end
 
   it "produces count" do


### PR DESCRIPTION
Event tracking likely will have different consumption behavior than the metrics/counting/instrumenting methods.

Also clarify names to avoid confusion with other uses of "event".